### PR TITLE
feat: shared pool — bias-resistant fact store with blind gate and temporal decay

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -717,6 +717,94 @@ memory/threads/archive/<threadId>/
 
 ---
 
+## Shared Pool
+
+The shared pool is a structured, bias-resistant fact store that agents write to and read from. It implements the architecture defined in `research/CONSENSUS_BIAS_ARCHITECTURE.md`.
+
+### Storage
+
+Pool file: `~/.openclaw/workspace/memory/shared/pool.json`
+Audit log: `~/.openclaw/workspace/memory/shared/audit.jsonl`
+Gate files: `~/.openclaw/workspace/memory/shared/gates/`
+
+On first write, the pool is initialized with seed entries from `shared-pool.json` in the project root.
+
+### Writing
+
+```js
+import { writeEntry } from './shared-pool-write.mjs';
+
+await writeEntry({
+  type: "fact",          // observation|fact|inference|interpretation|role-assignment|prediction
+  category: "infra",
+  fact: "Receiver is running on port 18801",
+  tags: ["infra", "receiver"],
+  provenance: {
+    source_agent: "liz",
+    timestamp: new Date().toISOString(),
+    basis: "observed",    // observed|inferred|peer-relayed|self-assessed|external
+    confidence: 0.95,
+  }
+});
+```
+
+Or via CLI:
+```bash
+node shared-pool-write.mjs --agent liz --fact "thing I observed" --category infra --basis observed --confidence 0.9
+```
+
+### Reading (with blind gate — required)
+
+Before reading the shared pool on any topic requiring a position, you MUST commit your independent assessment first:
+
+```js
+import { openGate, readWithGate } from './blind-gate.mjs';
+
+// 1. Form your own position
+// 2. Commit it (only hash is stored — not text)
+const token = await openGate("deployment-readiness", "liz", "I believe deployment is ready because...");
+
+// 3. Read with gate token
+const entries = await readWithGate(token, { category: "infra" });
+```
+
+Skipping the gate throws with a clear protocol explanation. Gates expire after 10 minutes unused.
+
+### Read-path anonymization
+
+At read time, `provenance.source_agent` is stripped and replaced with the agent's role (from `mesh-memory.contacts.json`). Full attribution is written to `audit.jsonl` for human review only. This prevents name-based authority bias between agents.
+
+### Confidence decay
+
+Entries automatically decay in confidence over time:
+- `slow` (facts/observations): 0.995/day
+- `medium` (inferences/role-assignments): 0.985/day
+- `fast` (interpretations): 0.97/day
+- `bounded` (predictions): 1.0 until `review_by` date, then 0.0
+
+Entries with `effective_confidence < 0.5` are marked `stale: true`.
+
+### Peer sync
+
+```js
+import { syncToPeers } from './shared-pool-sync.mjs';
+
+const peers = [{ url: "http://ray-host:18801", token: "BEARER_TOKEN" }];
+await syncToPeers(entries, peers);
+```
+
+Peers receive entries via `POST /mesh/shared-pool`. The receiver forces `provenance.basis = "peer-relayed"` on all received entries. Rate limited to 1 req/sec/peer.
+
+### Testing
+
+```bash
+node --test tests/shared-pool.test.mjs
+# or
+npm run test:pool
+```
+
+---
+
 ## Questions, Issues, Contributions
 
 This is a live project in active development. If something doesn't work as documented, open an issue at https://github.com/Better-Machine/mesh-memory/issues.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Install it on any OpenClaw agent. That agent now:
 - **Learns from mistakes** — tagged lessons, corrections, and decisions persist and survive session resets
 - **Consolidates nightly** — dream cycle runs at 2 AM, distilling recent context into long-term memory
 - **Respects privacy** — per-message and block-scoped suppression keeps sensitive context local
+- **Shared pool** — bias-resistant structured fact store across agents, with temporal decay, read-path anonymization, and pre-retrieval blind gate to prevent anchoring bias
 
 No peers required. No coordination. Works on day one with a single agent.
 

--- a/blind-gate.mjs
+++ b/blind-gate.mjs
@@ -1,0 +1,261 @@
+/**
+ * @module blind-gate
+ * @description Pre-retrieval commitment gate for the shared pool.
+ * Architecture: research/CONSENSUS_BIAS_ARCHITECTURE.md
+ *
+ * Protocol: write → commit position hash → gate opens → read pool
+ * Post-read "independent assessment" is contaminated by anchoring and
+ * does not count as independent. This gate enforces temporal ordering.
+ */
+
+import { createHash, randomBytes } from "node:crypto";
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { homedir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+import { appendFile } from "node:fs/promises";
+import { readAll } from "./shared-pool-read.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const WORKSPACE = resolve(homedir(), ".openclaw/workspace");
+const GATES_DIR = resolve(WORKSPACE, "memory/shared/gates");
+const AUDIT_FILE = resolve(WORKSPACE, "memory/shared/audit.jsonl");
+
+/** Gate expiry: 10 minutes in milliseconds */
+const GATE_TTL_MS = 10 * 60 * 1000;
+
+/**
+ * Compute sha256 of a string, returned as hex.
+ * @param {string} text
+ * @returns {string}
+ */
+function sha256(text) {
+  return createHash("sha256").update(text, "utf-8").digest("hex");
+}
+
+/**
+ * Generate a gate token (random 32-byte hex string).
+ * @returns {string}
+ */
+function generateToken() {
+  return randomBytes(32).toString("hex");
+}
+
+/**
+ * Sanitize a string for use in a filename.
+ * @param {string} s
+ * @returns {string}
+ */
+function sanitizeForFilename(s) {
+  return s.replace(/[^a-zA-Z0-9_-]/g, "_").slice(0, 64);
+}
+
+/**
+ * Get the file path for a gate file.
+ * @param {string} topic
+ * @param {string} agentId
+ * @param {string} timestamp - ISO string
+ * @returns {string}
+ */
+function gateFilePath(topic, agentId, timestamp) {
+  const safeTopic = sanitizeForFilename(topic);
+  const safeAgent = sanitizeForFilename(agentId);
+  const safeTs    = timestamp.replace(/[:.]/g, "-");
+  return resolve(GATES_DIR, `${safeTopic}-${safeAgent}-${safeTs}.json`);
+}
+
+/**
+ * Write to the audit log.
+ * @param {Object} record
+ */
+async function writeAudit(record) {
+  await mkdir(resolve(WORKSPACE, "memory/shared"), { recursive: true });
+  await appendFile(AUDIT_FILE, JSON.stringify(record) + "\n", "utf-8");
+}
+
+/**
+ * Open a blind gate — commit your position BEFORE reading the pool.
+ *
+ * Writes a position hash (not the position text) to a gate file.
+ * Returns a gateToken required to subsequently read.
+ *
+ * @param {string} topic - The topic you are about to research
+ * @param {string} agentId - Your agent ID
+ * @param {string} position - Your independent assessment (BEFORE reading pool)
+ * @returns {Promise<string>} gateToken to pass to readWithGate()
+ */
+export async function openGate(topic, agentId, position) {
+  if (!topic || typeof topic !== "string")
+    throw new Error("openGate: topic is required");
+  if (!agentId || typeof agentId !== "string")
+    throw new Error("openGate: agentId is required");
+  if (!position || typeof position !== "string")
+    throw new Error("openGate: position is required (your independent assessment before reading pool)");
+
+  await mkdir(GATES_DIR, { recursive: true });
+
+  const timestamp = new Date().toISOString();
+  const token = generateToken();
+  const positionHash = sha256(position);
+  const filePath = gateFilePath(topic, agentId, timestamp);
+
+  const gateData = {
+    token,
+    topic,
+    agentId,
+    positionHash,  // hash only — position text is NOT stored
+    openedAt: timestamp,
+    used: false,
+    filePath,
+  };
+
+  await writeFile(filePath, JSON.stringify(gateData, null, 2), "utf-8");
+
+  await writeAudit({
+    event: "gate_opened",
+    topic,
+    agentId,
+    positionHash,
+    openedAt: timestamp,
+    gateToken: token.slice(0, 8) + "...", // partial token in audit only
+  });
+
+  console.log(`[blind-gate] ✅ Gate opened for topic '${topic}' by '${agentId}' (expires in 10 min)`);
+  return token;
+}
+
+/**
+ * Read the shared pool using a valid gate token.
+ *
+ * Validates that:
+ * 1. A gate exists with the matching token
+ * 2. The gate is not yet used
+ * 3. The gate is not expired (< 10 min old)
+ *
+ * Marks gate as used after successful read.
+ *
+ * @param {string} gateToken - Token from openGate()
+ * @param {Object} [query] - Query/filter options for readAll()
+ * @returns {Promise<Array>} Pool entries (anonymized, decayed)
+ * @throws If no gate / expired / already used
+ */
+export async function readWithGate(gateToken, query = {}) {
+  if (!gateToken) {
+    throw new Error(
+      "[blind-gate] READ BLOCKED: No gate token provided.\n" +
+      "Protocol: You must call openGate(topic, agentId, yourPosition) BEFORE reading the shared pool.\n" +
+      "This ensures your assessment is independent and not contaminated by anchoring bias.\n" +
+      "1. Form your own position on the topic\n" +
+      "2. Call openGate() — this commits a hash of your position\n" +
+      "3. Call readWithGate() with the returned token\n" +
+      "Post-read 'independent' assessments do not count."
+    );
+  }
+
+  // Scan gates directory for matching token
+  if (!existsSync(GATES_DIR)) {
+    throw new Error("[blind-gate] READ BLOCKED: No gates directory found. Call openGate() first.");
+  }
+
+  const { readdir } = await import("node:fs/promises");
+  const files = await readdir(GATES_DIR);
+  let gateFile = null;
+  let gateData = null;
+
+  for (const file of files) {
+    if (!file.endsWith(".json")) continue;
+    const filePath = resolve(GATES_DIR, file);
+    try {
+      const data = JSON.parse(await readFile(filePath, "utf-8"));
+      if (data.token === gateToken) {
+        gateFile = filePath;
+        gateData = data;
+        break;
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  if (!gateData) {
+    throw new Error("[blind-gate] READ BLOCKED: Gate token not found. Call openGate() first.");
+  }
+
+  if (gateData.used) {
+    throw new Error(`[blind-gate] READ BLOCKED: Gate token already used. Each gate can only be used once. Call openGate() again.`);
+  }
+
+  // Check expiry
+  const age = Date.now() - new Date(gateData.openedAt).getTime();
+  if (age > GATE_TTL_MS) {
+    // Mark as expired in file
+    gateData.expired = true;
+    await writeFile(gateFile, JSON.stringify(gateData, null, 2), "utf-8");
+    throw new Error(
+      `[blind-gate] READ BLOCKED: Gate token expired (${Math.round(age / 60000)} min old; limit is 10 min).\n` +
+      "Call openGate() again with your current position."
+    );
+  }
+
+  // Mark gate as used
+  gateData.used = true;
+  gateData.usedAt = new Date().toISOString();
+  await writeFile(gateFile, JSON.stringify(gateData, null, 2), "utf-8");
+
+  // Read pool
+  const readerId = gateData.agentId;
+  const entries = await readAll({ ...query, readerId });
+
+  // Audit the read
+  await writeAudit({
+    event: "gate_read",
+    topic: gateData.topic,
+    agentId: gateData.agentId,
+    positionHash: gateData.positionHash,
+    openedAt: gateData.openedAt,
+    usedAt: gateData.usedAt,
+    entriesRead: entries.length,
+    filters: query,
+  });
+
+  console.log(`[blind-gate] ✅ Gate ${gateToken.slice(0, 8)}... used — read ${entries.length} entries.`);
+  return entries;
+}
+
+/**
+ * Check whether an agent has an active (unused, unexpired) gate.
+ * @param {string} agentId
+ * @param {string} [topic] - Optional: filter by topic
+ * @returns {Promise<boolean>}
+ */
+export async function hasActiveGate(agentId, topic) {
+  if (!existsSync(GATES_DIR)) return false;
+
+  const { readdir } = await import("node:fs/promises");
+  let files;
+  try {
+    files = await readdir(GATES_DIR);
+  } catch {
+    return false;
+  }
+
+  const now = Date.now();
+  for (const file of files) {
+    if (!file.endsWith(".json")) continue;
+    try {
+      const data = JSON.parse(await readFile(resolve(GATES_DIR, file), "utf-8"));
+      if (data.agentId !== agentId) continue;
+      if (topic && data.topic !== topic) continue;
+      if (data.used || data.expired) continue;
+      const age = now - new Date(data.openedAt).getTime();
+      if (age <= GATE_TTL_MS) return true;
+    } catch {
+      continue;
+    }
+  }
+
+  return false;
+}

--- a/memory-receiver.mjs
+++ b/memory-receiver.mjs
@@ -10,6 +10,7 @@ import { resolve } from "node:path";
 import { homedir } from "node:os";
 import { loadConfig } from "./config.mjs";
 import { detectTags, writeLessonEntry } from "./lesson-tagger.mjs";
+import { receiveFromPeer } from "./shared-pool-sync.mjs";
 
 const MESH_DIR = resolve(homedir(), ".openclaw/workspace/memory/mesh");
 
@@ -145,6 +146,27 @@ async function main() {
       return res.status(200).json({ ok: true });
     } catch (err) {
       console.error("[receiver] Write error:", err.message);
+      return res.status(500).json({ error: "Internal server error" });
+    }
+  });
+
+  /**
+   * POST /mesh/shared-pool — Receive a shared pool entry from a peer agent.
+   * Returns 201 on success, 409 on duplicate ID, 400 on invalid entry.
+   */
+  app.post("/mesh/shared-pool", async (req, res) => {
+    try {
+      const entry = await receiveFromPeer(req.body);
+      console.log(`[receiver] 🗂  Shared pool entry received: ${entry.id} (${entry.type})`);
+      return res.status(201).json({ ok: true, id: entry.id });
+    } catch (err) {
+      if (err.code === "DUPLICATE") {
+        return res.status(409).json({ error: "Duplicate entry ID", id: req.body?.id });
+      }
+      if (err.code === "INVALID") {
+        return res.status(400).json({ error: err.message });
+      }
+      console.error("[receiver] Shared pool write error:", err.message);
       return res.status(500).json({ error: "Internal server error" });
     }
   });

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "stress-test": "node stress-test.mjs",
     "threads": "node thread-manager.mjs",
     "rotate": "node rotate-storage.mjs",
-    "start": "concurrently \"npm run watcher\" \"npm run receiver\" \"npm run bridge\" \"npm run threads\""
+    "start": "concurrently \"npm run watcher\" \"npm run receiver\" \"npm run bridge\" \"npm run threads\"",
+    "shared-pool": "node shared-pool-write.mjs",
+    "test:pool": "node --test tests/shared-pool.test.mjs"
   },
   "dependencies": {
     "express": "^4.18.0",

--- a/shared-pool-read.mjs
+++ b/shared-pool-read.mjs
@@ -1,0 +1,267 @@
+/**
+ * @module shared-pool-read
+ * @description Read from the shared pool with mandatory anonymization and confidence decay.
+ * Architecture: research/CONSENSUS_BIAS_ARCHITECTURE.md
+ *
+ * READ-PATH ANONYMIZATION IS MANDATORY — see architecture doc.
+ * Full attribution is written to audit.jsonl for human review only.
+ */
+
+import { readFile, appendFile, mkdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { homedir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const WORKSPACE = resolve(homedir(), ".openclaw/workspace");
+const POOL_DIR = resolve(WORKSPACE, "memory/shared");
+const POOL_FILE = resolve(POOL_DIR, "pool.json");
+const AUDIT_FILE = resolve(POOL_DIR, "audit.jsonl");
+const CONTACTS_FILE = resolve(__dirname, "mesh-memory.contacts.json");
+
+/** Decay rates per day */
+const DECAY_PER_DAY = {
+  slow:    0.995,
+  medium:  0.985,
+  fast:    0.97,
+  bounded: null, // special logic
+};
+
+const STALE_THRESHOLD = 0.5;
+
+/** Load contacts registry for agent→role mapping */
+let _contacts = null;
+async function loadContacts() {
+  if (_contacts) return _contacts;
+  if (!existsSync(CONTACTS_FILE)) {
+    _contacts = {};
+    return _contacts;
+  }
+  try {
+    const data = JSON.parse(await readFile(CONTACTS_FILE, "utf-8"));
+    _contacts = data.contacts || {};
+  } catch {
+    _contacts = {};
+  }
+  return _contacts;
+}
+
+/**
+ * Map a source_agent name to an anonymized role/domain label.
+ * @param {string} sourceAgent
+ * @param {Object} contacts
+ * @returns {string} anonymized label
+ */
+function anonymizeAgent(sourceAgent, contacts) {
+  // Try to find matching contact by name field
+  for (const [, contact] of Object.entries(contacts)) {
+    if (
+      contact.name &&
+      contact.name.toLowerCase().includes(sourceAgent.toLowerCase())
+    ) {
+      return contact.role || "agent";
+    }
+  }
+  // Try direct key match (e.g. "agent:liz")
+  const byKey = contacts[`agent:${sourceAgent.toLowerCase()}`];
+  if (byKey) return byKey.role || "agent";
+  return "agent";
+}
+
+/**
+ * Calculate effective confidence with temporal decay.
+ * @param {Object} entry
+ * @returns {{effective_confidence: number, stale: boolean}}
+ */
+function applyDecay(entry) {
+  const { confidence, review_by } = entry.provenance;
+  const decayRate = entry.decay_rate;
+  const writtenAt = new Date(entry.provenance.timestamp);
+  const now = new Date();
+  const ageInDays = Math.max(0, (now - writtenAt) / (1000 * 60 * 60 * 24));
+
+  let effective_confidence;
+
+  if (decayRate === "bounded") {
+    // 1.0 until review_by, then 0.0
+    if (review_by && now > new Date(review_by)) {
+      effective_confidence = 0.0;
+    } else {
+      effective_confidence = confidence;
+    }
+  } else {
+    const ratePerDay = DECAY_PER_DAY[decayRate] ?? DECAY_PER_DAY.fast;
+    const multiplier = Math.pow(ratePerDay, ageInDays);
+    effective_confidence = confidence * multiplier;
+  }
+
+  return {
+    effective_confidence: Math.max(0, Math.min(1, effective_confidence)),
+    stale: effective_confidence < STALE_THRESHOLD,
+  };
+}
+
+/**
+ * Write a full-attribution record to audit log (never shown to reading agent).
+ * @param {Object} rawEntry - Full entry with real source_agent
+ * @param {string} readerId - Who is reading (for audit trail)
+ */
+async function writeAudit(rawEntry, readerId) {
+  await mkdir(POOL_DIR, { recursive: true });
+  const record = {
+    event: "read",
+    entry_id: rawEntry.id,
+    full_source_agent: rawEntry.provenance.source_agent,
+    reader: readerId || "unknown",
+    read_at: new Date().toISOString(),
+  };
+  await appendFile(AUDIT_FILE, JSON.stringify(record) + "\n", "utf-8");
+}
+
+/**
+ * Load and parse the pool file.
+ * @returns {Promise<Array>} entries array
+ */
+async function loadPoolEntries() {
+  if (!existsSync(POOL_FILE)) return [];
+  const raw = JSON.parse(await readFile(POOL_FILE, "utf-8"));
+  return raw.entries || [];
+}
+
+/**
+ * Anonymize and enrich a single entry for reading.
+ * @param {Object} rawEntry
+ * @param {Object} contacts
+ * @param {string} [readerId]
+ * @returns {Object} Safe, decayed entry
+ */
+async function presentEntry(rawEntry, contacts, readerId) {
+  const { effective_confidence, stale } = applyDecay(rawEntry);
+  const anonymizedRole = anonymizeAgent(rawEntry.provenance.source_agent, contacts);
+
+  // Write audit trail BEFORE returning to reader
+  await writeAudit(rawEntry, readerId);
+
+  const entry = {
+    id: rawEntry.id,
+    type: rawEntry.type,
+    category: rawEntry.category,
+    fact: rawEntry.fact,
+    tags: rawEntry.tags,
+    provenance: {
+      // source_agent is STRIPPED — replaced with role
+      source: anonymizedRole,
+      timestamp: rawEntry.provenance.timestamp,
+      basis: rawEntry.provenance.basis,
+      review_by: rawEntry.provenance.review_by,
+    },
+    confirmed_by: rawEntry.confirmed_by,
+    decay_rate: rawEntry.decay_rate,
+    effective_confidence,
+    stale,
+    challenges: rawEntry.challenges || [],
+  };
+
+  // Prepend challenge warning if any challenges exist
+  if (entry.challenges.length > 0) {
+    entry._warning = `[CHALLENGE] This entry has ${entry.challenges.length} challenge(s). Review challenges before relying on this fact.`;
+  }
+
+  return entry;
+}
+
+/**
+ * Read all entries from the shared pool.
+ * @param {Object} [opts] - Filter options
+ * @param {boolean} [opts.includeStale=false] - Include stale entries
+ * @param {string}  [opts.category] - Filter by category
+ * @param {string[]} [opts.tags] - Filter by tags (any match)
+ * @param {string}  [opts.type] - Filter by type
+ * @param {string}  [opts.readerId] - ID of the reading agent (for audit)
+ * @returns {Promise<Array>}
+ */
+export async function readAll(opts = {}) {
+  const {
+    includeStale = false,
+    category,
+    tags,
+    type,
+    readerId,
+  } = opts;
+
+  const [rawEntries, contacts] = await Promise.all([
+    loadPoolEntries(),
+    loadContacts(),
+  ]);
+
+  const results = [];
+  for (const raw of rawEntries) {
+    const entry = await presentEntry(raw, contacts, readerId);
+    if (!includeStale && entry.stale) continue;
+    if (category && entry.category !== category) continue;
+    if (type && entry.type !== type) continue;
+    if (tags && tags.length > 0) {
+      const hasTag = tags.some(t => entry.tags.includes(t));
+      if (!hasTag) continue;
+    }
+    results.push(entry);
+  }
+
+  return results;
+}
+
+/**
+ * Read a single entry by ID.
+ * @param {string} id
+ * @param {string} [readerId]
+ * @returns {Promise<Object|null>}
+ */
+export async function readOne(id, readerId) {
+  const [rawEntries, contacts] = await Promise.all([
+    loadPoolEntries(),
+    loadContacts(),
+  ]);
+
+  const raw = rawEntries.find(e => e.id === id);
+  if (!raw) return null;
+
+  return presentEntry(raw, contacts, readerId);
+}
+
+/**
+ * Search entries by query string (matches fact, category, tags).
+ * @param {string} query
+ * @param {Object} [opts]
+ * @param {boolean} [opts.includeStale=false]
+ * @param {string}  [opts.readerId]
+ * @returns {Promise<Array>}
+ */
+export async function search(query, opts = {}) {
+  const { includeStale = false, readerId } = opts;
+  const q = query.toLowerCase();
+
+  const [rawEntries, contacts] = await Promise.all([
+    loadPoolEntries(),
+    loadContacts(),
+  ]);
+
+  const results = [];
+  for (const raw of rawEntries) {
+    const entry = await presentEntry(raw, contacts, readerId);
+    if (!includeStale && entry.stale) continue;
+
+    const inFact     = entry.fact.toLowerCase().includes(q);
+    const inCategory = entry.category.toLowerCase().includes(q);
+    const inTags     = entry.tags.some(t => t.toLowerCase().includes(q));
+    const inType     = entry.type.toLowerCase().includes(q);
+
+    if (inFact || inCategory || inTags || inType) {
+      results.push(entry);
+    }
+  }
+
+  return results;
+}

--- a/shared-pool-sync.mjs
+++ b/shared-pool-sync.mjs
@@ -1,0 +1,208 @@
+/**
+ * @module shared-pool-sync
+ * @description Sync shared pool entries to/from peer agents.
+ * Architecture: research/CONSENSUS_BIAS_ARCHITECTURE.md
+ */
+
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { homedir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+import { writeEntry } from "./shared-pool-write.mjs";
+import { loadConfig } from "./config.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const WORKSPACE = resolve(homedir(), ".openclaw/workspace");
+const POOL_DIR = resolve(WORKSPACE, "memory/shared");
+const SYNC_STATE_FILE = resolve(POOL_DIR, "sync-state.json");
+
+/** Rate limit: max 1 request/sec/peer */
+const RATE_LIMIT_MS = 1000;
+
+/**
+ * Load sync state (cursor per peer).
+ * @returns {Promise<Object>}
+ */
+async function loadSyncState() {
+  if (!existsSync(SYNC_STATE_FILE)) {
+    return { cursors: {}, lastSync: {} };
+  }
+  return JSON.parse(await readFile(SYNC_STATE_FILE, "utf-8"));
+}
+
+/**
+ * Save sync state.
+ * @param {Object} state
+ */
+async function saveSyncState(state) {
+  await mkdir(POOL_DIR, { recursive: true });
+  await writeFile(SYNC_STATE_FILE, JSON.stringify(state, null, 2), "utf-8");
+}
+
+/**
+ * Sleep for ms milliseconds.
+ * @param {number} ms
+ */
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * POST a single entry to a peer's /mesh/shared-pool endpoint.
+ * @param {Object} entry
+ * @param {Object} peer - { url, token }
+ * @returns {Promise<{ok: boolean, status: number, duplicate: boolean}>}
+ */
+async function postEntryToPeer(entry, peer) {
+  const config = loadConfig();
+  const token = peer.token || config.receiverToken;
+
+  let res;
+  try {
+    res = await fetch(`${peer.url}/mesh/shared-pool`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify(entry),
+      signal: AbortSignal.timeout(10000),
+    });
+  } catch (e) {
+    console.warn(`[shared-pool-sync] Peer ${peer.url} unreachable:`, e.message);
+    return { ok: false, status: 0, duplicate: false };
+  }
+
+  return {
+    ok: res.status === 201,
+    status: res.status,
+    duplicate: res.status === 409,
+  };
+}
+
+/**
+ * Sync new entries to a list of peer receivers.
+ * Rate limited: max 1 req/sec/peer.
+ *
+ * @param {Object[]} entries - Entries to sync
+ * @param {Object[]} peers - Array of { url, token } objects
+ * @returns {Promise<Object>} Summary: { sent, duplicates, errors } per peer
+ */
+export async function syncToPeers(entries, peers) {
+  if (!Array.isArray(entries) || entries.length === 0) {
+    console.log("[shared-pool-sync] No entries to sync.");
+    return {};
+  }
+  if (!Array.isArray(peers) || peers.length === 0) {
+    console.log("[shared-pool-sync] No peers configured.");
+    return {};
+  }
+
+  const state = await loadSyncState();
+  const summary = {};
+
+  for (const peer of peers) {
+    const peerKey = peer.url;
+    const cursor = state.cursors[peerKey] || 0;
+    const toSend = entries.slice(cursor);
+
+    if (toSend.length === 0) {
+      console.log(`[shared-pool-sync] Peer ${peerKey}: already up to date.`);
+      summary[peerKey] = { sent: 0, duplicates: 0, errors: 0 };
+      continue;
+    }
+
+    console.log(`[shared-pool-sync] Syncing ${toSend.length} entries to ${peerKey}...`);
+
+    let sent = 0;
+    let duplicates = 0;
+    let errors = 0;
+
+    for (let i = 0; i < toSend.length; i++) {
+      const entry = toSend[i];
+      const result = await postEntryToPeer(entry, peer);
+
+      if (result.ok) {
+        sent++;
+        state.cursors[peerKey] = cursor + i + 1;
+      } else if (result.duplicate) {
+        duplicates++;
+        state.cursors[peerKey] = cursor + i + 1;
+      } else {
+        errors++;
+        console.warn(`[shared-pool-sync] Failed to sync entry ${entry.id} to ${peerKey} (status ${result.status})`);
+      }
+
+      // Rate limit: 1 req/sec/peer
+      if (i < toSend.length - 1) {
+        await sleep(RATE_LIMIT_MS);
+      }
+    }
+
+    state.lastSync[peerKey] = new Date().toISOString();
+    summary[peerKey] = { sent, duplicates, errors };
+    console.log(`[shared-pool-sync] ${peerKey}: sent=${sent} duplicates=${duplicates} errors=${errors}`);
+  }
+
+  await saveSyncState(state);
+  return summary;
+}
+
+/**
+ * Validate a pool entry received from a peer.
+ * @param {Object} entry
+ * @returns {string|null} Error message or null if valid
+ */
+function validatePeerEntry(entry) {
+  if (!entry || typeof entry !== "object") return "Entry must be a JSON object";
+  if (!entry.id) return "Missing required field: id";
+  if (!entry.fact) return "Missing required field: fact";
+  if (!entry.category) return "Missing required field: category";
+  if (!Array.isArray(entry.tags)) return "Missing required field: tags";
+  if (!entry.provenance || typeof entry.provenance !== "object")
+    return "Missing required field: provenance";
+  if (!entry.provenance.source_agent) return "Missing required field: provenance.source_agent";
+  if (!entry.provenance.timestamp)    return "Missing required field: provenance.timestamp";
+  if (entry.provenance.confidence === undefined || entry.provenance.confidence === null)
+    return "Missing required field: provenance.confidence";
+  return null;
+}
+
+/**
+ * Receive a pool entry from a peer agent.
+ * - Validates the entry structure
+ * - Checks for duplicate IDs
+ * - Forces provenance.basis to "peer-relayed"
+ *
+ * @param {Object} entry - Entry from peer
+ * @returns {Promise<Object>} Written entry
+ * @throws If invalid or duplicate
+ */
+export async function receiveFromPeer(entry) {
+  const error = validatePeerEntry(entry);
+  if (error) {
+    throw Object.assign(new Error(`Invalid peer entry: ${error}`), { code: "INVALID" });
+  }
+
+  // Force basis to "peer-relayed" regardless of what peer sent
+  const normalized = {
+    ...entry,
+    provenance: {
+      ...entry.provenance,
+      basis: "peer-relayed",
+    },
+  };
+
+  // writeEntry handles duplicate ID rejection
+  try {
+    return await writeEntry(normalized);
+  } catch (e) {
+    if (e.message && e.message.startsWith("Duplicate entry ID")) {
+      throw Object.assign(e, { code: "DUPLICATE" });
+    }
+    throw e;
+  }
+}

--- a/shared-pool-write.mjs
+++ b/shared-pool-write.mjs
@@ -1,0 +1,296 @@
+/**
+ * @module shared-pool-write
+ * @description Write entries to the shared pool — bias-resistant fact store.
+ * Architecture: research/CONSENSUS_BIAS_ARCHITECTURE.md
+ */
+
+import { createHash } from "node:crypto";
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { homedir } from "node:os";
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const WORKSPACE = resolve(homedir(), ".openclaw/workspace");
+const POOL_DIR = resolve(WORKSPACE, "memory/shared");
+const POOL_FILE = resolve(POOL_DIR, "pool.json");
+const SEED_FILE = resolve(__dirname, "shared-pool.json");
+
+const VALID_TYPES = [
+  "observation",
+  "fact",
+  "inference",
+  "interpretation",
+  "role-assignment",
+  "prediction",
+];
+
+const VALID_BASES = [
+  "observed",
+  "inferred",
+  "peer-relayed",
+  "self-assessed",
+  "external",
+];
+
+/** Map type → decay_rate */
+const DECAY_RATE_MAP = {
+  fact: "slow",
+  observation: "slow",
+  inference: "medium",
+  "role-assignment": "medium",
+  interpretation: "fast",
+  prediction: "bounded",
+};
+
+/** Map type → review window (in days, except predictions which use deadline) */
+const REVIEW_WINDOW_DAYS = {
+  fact: 180,
+  observation: 180,
+  inference: 90,
+  "role-assignment": 90,
+  interpretation: 42, // 6 weeks
+  prediction: null,   // caller must supply
+};
+
+/**
+ * Compute a deterministic entry ID.
+ * sha256(source_agent + timestamp + fact.slice(0,64))
+ * @param {string} sourceAgent
+ * @param {string} timestamp
+ * @param {string} fact
+ * @returns {string} hex digest (first 32 chars)
+ */
+function computeId(sourceAgent, timestamp, fact) {
+  const input = `${sourceAgent}||${timestamp}||${fact.slice(0, 64)}`;
+  return createHash("sha256").update(input).digest("hex").slice(0, 32);
+}
+
+/**
+ * Compute review_by date from type and optional deadline.
+ * @param {string} type
+ * @param {string} [deadline] - ISO date for predictions
+ * @returns {string} ISO date string
+ */
+function computeReviewBy(type, deadline) {
+  if (type === "prediction") {
+    if (!deadline) throw new Error('Predictions require provenance.review_by (prediction deadline)');
+    return deadline;
+  }
+  const days = REVIEW_WINDOW_DAYS[type] ?? 180;
+  const d = new Date();
+  d.setDate(d.getDate() + days);
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Load the pool from disk, initializing if absent.
+ * On first init, merges seed entries from shared-pool.json.
+ * @returns {Promise<{version: string, entries: Array}>}
+ */
+async function loadPool() {
+  await mkdir(POOL_DIR, { recursive: true });
+
+  if (!existsSync(POOL_FILE)) {
+    // Initialize fresh pool
+    const pool = { version: "0.2", entries: [] };
+
+    // Merge seed entries if seed file exists
+    if (existsSync(SEED_FILE)) {
+      try {
+        const seed = JSON.parse(await readFile(SEED_FILE, "utf-8"));
+        if (Array.isArray(seed.entries)) {
+          for (const raw of seed.entries) {
+            // Convert legacy seed format → pool format
+            const entry = normalizeSeedEntry(raw);
+            if (entry) pool.entries.push(entry);
+          }
+          console.log(`[shared-pool-write] Merged ${pool.entries.length} seed entries.`);
+        }
+      } catch (e) {
+        console.warn("[shared-pool-write] Could not read seed file:", e.message);
+      }
+    }
+
+    await writeFile(POOL_FILE, JSON.stringify(pool, null, 2), "utf-8");
+    return pool;
+  }
+
+  return JSON.parse(await readFile(POOL_FILE, "utf-8"));
+}
+
+/**
+ * Convert a legacy seed entry (shared-pool.json format) to pool format.
+ * @param {Object} raw
+ * @returns {Object|null}
+ */
+function normalizeSeedEntry(raw) {
+  if (!raw.fact || !raw.id) return null;
+  const author = raw.author || "unknown";
+  const timestamp = raw.date
+    ? new Date(raw.date).toISOString()
+    : new Date().toISOString();
+  return {
+    id: raw.id,
+    type: "fact",
+    category: raw.category || "general",
+    fact: raw.fact,
+    tags: raw.tags || [],
+    provenance: {
+      source_agent: author,
+      timestamp,
+      basis: "observed",
+      confidence: 0.9,
+      review_by: computeReviewBy("fact"),
+    },
+    confirmed_by: raw.confirmed_by || null,
+    decay_rate: "slow",
+    challenges: [],
+  };
+}
+
+/**
+ * Save pool to disk.
+ * @param {Object} pool
+ */
+async function savePool(pool) {
+  await writeFile(POOL_FILE, JSON.stringify(pool, null, 2), "utf-8");
+}
+
+/**
+ * Validate a candidate entry. Throws on hard errors, warns on soft.
+ * @param {Object} entry - Input entry (may be mutated for defaults)
+ * @returns {Object} Normalized entry
+ */
+function validateAndNormalize(entry) {
+  const errors = [];
+
+  // ── Required top-level fields ─────────────────────────────────────
+  if (!entry.fact || typeof entry.fact !== "string")
+    errors.push("Missing required field: fact");
+  if (!entry.category || typeof entry.category !== "string")
+    errors.push("Missing required field: category");
+  if (!Array.isArray(entry.tags))
+    errors.push("Missing required field: tags (must be array)");
+
+  // ── Provenance ────────────────────────────────────────────────────
+  const prov = entry.provenance;
+  if (!prov || typeof prov !== "object")
+    errors.push("Missing required field: provenance");
+  else {
+    if (!prov.source_agent) errors.push("Missing required field: provenance.source_agent");
+    if (!prov.timestamp)    errors.push("Missing required field: provenance.timestamp");
+    if (prov.confidence === undefined || prov.confidence === null)
+      errors.push("Missing required field: provenance.confidence");
+    if (!prov.basis)        errors.push("Missing required field: provenance.basis");
+    else if (!VALID_BASES.includes(prov.basis))
+      errors.push(`Invalid provenance.basis: ${prov.basis}. Must be one of: ${VALID_BASES.join(", ")}`);
+    if (typeof prov.confidence === "number" &&
+        (prov.confidence < 0 || prov.confidence > 1))
+      errors.push("provenance.confidence must be 0.0–1.0");
+  }
+
+  if (errors.length > 0) throw new Error(`Validation failed:\n  ${errors.join("\n  ")}`);
+
+  // ── Type defaulting ───────────────────────────────────────────────
+  let type = entry.type;
+  if (!type) {
+    console.warn("[shared-pool-write] ⚠  Missing type — defaulting to 'interpretation'");
+    type = "interpretation";
+  } else if (!VALID_TYPES.includes(type)) {
+    console.warn(`[shared-pool-write] ⚠  Unknown type '${type}' — defaulting to 'interpretation'`);
+    type = "interpretation";
+  }
+
+  // ── Compute derived fields ────────────────────────────────────────
+  const ts = prov.timestamp;
+  const id = entry.id || computeId(prov.source_agent, ts, entry.fact);
+  const decay_rate = DECAY_RATE_MAP[type] || "fast";
+  const review_by = prov.review_by || computeReviewBy(type, entry._predictionDeadline);
+
+  return {
+    id,
+    type,
+    category: entry.category,
+    fact: entry.fact,
+    tags: entry.tags,
+    provenance: {
+      source_agent: prov.source_agent,
+      timestamp: ts,
+      basis: prov.basis,
+      confidence: prov.confidence,
+      review_by,
+    },
+    confirmed_by: entry.confirmed_by || null,
+    decay_rate,
+    challenges: [],
+  };
+}
+
+/**
+ * Write a single entry to the shared pool.
+ * @param {Object} entry - Entry object (see module docs for required fields)
+ * @returns {Promise<Object>} The normalized, written entry
+ */
+export async function writeEntry(entry) {
+  const normalized = validateAndNormalize(entry);
+  const pool = await loadPool();
+
+  // ── Duplicate ID check ────────────────────────────────────────────
+  if (pool.entries.some(e => e.id === normalized.id)) {
+    throw new Error(`Duplicate entry ID: ${normalized.id}`);
+  }
+
+  pool.entries.push(normalized);
+  await savePool(pool);
+
+  console.log(`[shared-pool-write] ✅ Written entry ${normalized.id} (${normalized.type}/${normalized.category})`);
+  return normalized;
+}
+
+// ── CLI usage ─────────────────────────────────────────────────────────────────
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const usage = `
+Usage: node shared-pool-write.mjs --agent <name> --fact <text> --category <cat> [--type <type>] [--tags tag1,tag2] [--basis <basis>] [--confidence 0.8]
+`;
+  const args = process.argv.slice(2);
+  const get = (flag) => {
+    const i = args.indexOf(flag);
+    return i !== -1 ? args[i + 1] : null;
+  };
+
+  const agent    = get("--agent");
+  const fact     = get("--fact");
+  const category = get("--category");
+  const type     = get("--type") || undefined;
+  const tags     = get("--tags") ? get("--tags").split(",") : [];
+  const basis    = get("--basis") || "observed";
+  const confidence = parseFloat(get("--confidence") || "0.8");
+
+  if (!agent || !fact || !category) {
+    console.error(usage);
+    process.exit(1);
+  }
+
+  try {
+    const result = await writeEntry({
+      type,
+      category,
+      fact,
+      tags,
+      provenance: {
+        source_agent: agent,
+        timestamp: new Date().toISOString(),
+        basis,
+        confidence,
+      },
+    });
+    console.log("Written:", result.id);
+  } catch (e) {
+    console.error("Error:", e.message);
+    process.exit(1);
+  }
+}

--- a/tests/shared-pool.test.mjs
+++ b/tests/shared-pool.test.mjs
@@ -1,0 +1,485 @@
+/**
+ * @file shared-pool.test.mjs
+ * @description Tests for shared pool write, read, blind gate, and peer sync.
+ * Uses Node built-in node:test and node:assert.
+ */
+
+import { test, describe, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync, writeFileSync, existsSync, rmSync, mkdirSync } from "node:fs";
+import { readFile, writeFile, mkdir, rm } from "node:fs/promises";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { homedir } from "node:os";
+import { randomUUID } from "node:crypto";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+
+const WORKSPACE = resolve(homedir(), ".openclaw/workspace");
+const POOL_DIR = resolve(WORKSPACE, "memory/shared");
+const POOL_FILE = resolve(POOL_DIR, "pool.json");
+const GATES_DIR = resolve(POOL_DIR, "gates");
+const AUDIT_FILE = resolve(POOL_DIR, "audit.jsonl");
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Back up and clear the pool for test isolation */
+let poolBackup = null;
+
+async function clearPool() {
+  poolBackup = existsSync(POOL_FILE)
+    ? JSON.parse(readFileSync(POOL_FILE, "utf-8"))
+    : null;
+  await mkdir(POOL_DIR, { recursive: true });
+  await writeFile(POOL_FILE, JSON.stringify({ version: "0.2", entries: [] }, null, 2));
+}
+
+async function restorePool() {
+  if (poolBackup !== null) {
+    await writeFile(POOL_FILE, JSON.stringify(poolBackup, null, 2));
+  } else if (existsSync(POOL_FILE)) {
+    await rm(POOL_FILE);
+  }
+}
+
+/** Create a minimal valid entry */
+function makeEntry(overrides = {}) {
+  const ts = new Date().toISOString();
+  return {
+    type: "fact",
+    category: "test",
+    fact: `Test fact ${randomUUID()}`,
+    tags: ["test"],
+    provenance: {
+      source_agent: "test-agent",
+      timestamp: ts,
+      basis: "observed",
+      confidence: 0.9,
+    },
+    ...overrides,
+  };
+}
+
+// ─── Write tests ──────────────────────────────────────────────────────────────
+
+describe("shared-pool-write", () => {
+  before(async () => {
+    await clearPool();
+  });
+
+  after(async () => {
+    await restorePool();
+  });
+
+  test("write success — returns normalized entry with id and decay_rate", async () => {
+    const { writeEntry } = await import(`../shared-pool-write.mjs?t=${Date.now()}`);
+    const entry = makeEntry({ type: "fact", category: "infra", fact: "The sky is blue" });
+    const result = await writeEntry(entry);
+
+    assert.ok(result.id, "should have an id");
+    assert.equal(result.type, "fact");
+    assert.equal(result.category, "infra");
+    assert.equal(result.decay_rate, "slow");
+    assert.deepEqual(result.challenges, []);
+    assert.ok(result.provenance.review_by, "should have review_by");
+  });
+
+  test("write missing fact — throws validation error", async () => {
+    const { writeEntry } = await import(`../shared-pool-write.mjs?t=${Date.now()}`);
+    const entry = makeEntry();
+    delete entry.fact;
+
+    await assert.rejects(
+      () => writeEntry(entry),
+      /Missing required field: fact/
+    );
+  });
+
+  test("write missing category — throws validation error", async () => {
+    const { writeEntry } = await import(`../shared-pool-write.mjs?t=${Date.now()}`);
+    const entry = makeEntry();
+    delete entry.category;
+
+    await assert.rejects(
+      () => writeEntry(entry),
+      /Missing required field: category/
+    );
+  });
+
+  test("write missing provenance — throws validation error", async () => {
+    const { writeEntry } = await import(`../shared-pool-write.mjs?t=${Date.now()}`);
+    const entry = makeEntry();
+    delete entry.provenance;
+
+    await assert.rejects(
+      () => writeEntry(entry),
+      /Missing required field: provenance/
+    );
+  });
+
+  test("write missing provenance.source_agent — throws", async () => {
+    const { writeEntry } = await import(`../shared-pool-write.mjs?t=${Date.now()}`);
+    const entry = makeEntry();
+    delete entry.provenance.source_agent;
+
+    await assert.rejects(
+      () => writeEntry(entry),
+      /provenance.source_agent/
+    );
+  });
+
+  test("write missing type — defaults to 'interpretation' with warning", async () => {
+    const { writeEntry } = await import(`../shared-pool-write.mjs?t=${Date.now()}`);
+    const entry = makeEntry();
+    delete entry.type;
+
+    const result = await writeEntry(entry);
+    assert.equal(result.type, "interpretation", "should default to interpretation");
+    assert.equal(result.decay_rate, "fast", "interpretation has fast decay");
+  });
+
+  test("duplicate ID rejection — throws on second write", async () => {
+    const { writeEntry } = await import(`../shared-pool-write.mjs?t=${Date.now()}`);
+    const entry = makeEntry({ fact: "Duplicate test fact" });
+
+    const first = await writeEntry(entry);
+
+    // Second write with same ID
+    await assert.rejects(
+      () => writeEntry({ ...entry, id: first.id }),
+      /Duplicate entry ID/
+    );
+  });
+
+  test("role-assignment decay_rate is 'medium'", async () => {
+    const { writeEntry } = await import(`../shared-pool-write.mjs?t=${Date.now()}`);
+    const entry = makeEntry({ type: "role-assignment", fact: "Agent X handles infra" });
+    const result = await writeEntry(entry);
+    assert.equal(result.decay_rate, "medium");
+  });
+
+  test("prediction decay_rate is 'bounded' and requires review_by", async () => {
+    const { writeEntry } = await import(`../shared-pool-write.mjs?t=${Date.now()}`);
+    const deadline = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+    const entry = makeEntry({
+      type: "prediction",
+      fact: "Deployment by Q2",
+      provenance: {
+        source_agent: "test-agent",
+        timestamp: new Date().toISOString(),
+        basis: "inferred",
+        confidence: 0.7,
+        review_by: deadline,
+      },
+    });
+    const result = await writeEntry(entry);
+    assert.equal(result.decay_rate, "bounded");
+    assert.equal(result.provenance.review_by, deadline);
+  });
+});
+
+// ─── Read tests ───────────────────────────────────────────────────────────────
+
+describe("shared-pool-read", () => {
+  let writtenId = null;
+
+  before(async () => {
+    await clearPool();
+    // Write a known entry for read tests
+    const { writeEntry } = await import(`../shared-pool-write.mjs?t=${Date.now()}`);
+    const entry = await writeEntry(makeEntry({
+      type: "fact",
+      category: "infra",
+      fact: "Read test fact",
+      tags: ["read-test"],
+      provenance: {
+        source_agent: "liz",
+        timestamp: new Date().toISOString(),
+        basis: "observed",
+        confidence: 0.9,
+      },
+    }));
+    writtenId = entry.id;
+  });
+
+  after(async () => {
+    await restorePool();
+  });
+
+  test("readAll returns entries without source_agent", async () => {
+    const { readAll } = await import(`../shared-pool-read.mjs?t=${Date.now()}`);
+    const entries = await readAll({ includeStale: true });
+    assert.ok(entries.length > 0);
+    for (const e of entries) {
+      assert.ok(!e.provenance.source_agent, "source_agent should be stripped");
+      assert.ok(e.provenance.source, "should have anonymized source role");
+    }
+  });
+
+  test("readOne returns single entry by id", async () => {
+    const { readOne } = await import(`../shared-pool-read.mjs?t=${Date.now()}`);
+    const entry = await readOne(writtenId, "test-reader");
+    assert.ok(entry, "should find entry");
+    assert.equal(entry.id, writtenId);
+  });
+
+  test("readOne returns null for unknown id", async () => {
+    const { readOne } = await import(`../shared-pool-read.mjs?t=${Date.now()}`);
+    const result = await readOne("nonexistent-id");
+    assert.equal(result, null);
+  });
+
+  test("search finds entries by fact content", async () => {
+    const { search } = await import(`../shared-pool-read.mjs?t=${Date.now()}`);
+    const results = await search("Read test fact", { includeStale: true });
+    assert.ok(results.some(e => e.id === writtenId));
+  });
+
+  test("read anonymization — source_agent replaced with role", async () => {
+    const { readOne } = await import(`../shared-pool-read.mjs?t=${Date.now()}`);
+    const entry = await readOne(writtenId);
+    assert.ok(!entry.provenance.source_agent, "source_agent must be stripped");
+    // 'liz' maps to 'agent' role in contacts or defaults to 'agent'
+    assert.ok(typeof entry.provenance.source === "string");
+  });
+
+  test("decay calculation — fresh entry has high effective_confidence", async () => {
+    const { readOne } = await import(`../shared-pool-read.mjs?t=${Date.now()}`);
+    const entry = await readOne(writtenId, "test-reader");
+    // Fresh entry (seconds old) should have ~original confidence
+    assert.ok(entry.effective_confidence > 0.8, `expected > 0.8, got ${entry.effective_confidence}`);
+    assert.equal(entry.stale, false);
+  });
+
+  test("stale flag — entry with very old timestamp and fast decay", async () => {
+    await clearPool();
+    const { writeEntry } = await import(`../shared-pool-write.mjs?t=${Date.now()}`);
+    const { readOne } = await import(`../shared-pool-read.mjs?t=${Date.now()}`);
+
+    // Write with old timestamp (200 days ago)
+    const oldDate = new Date(Date.now() - 200 * 24 * 60 * 60 * 1000);
+    const entry = await writeEntry(makeEntry({
+      type: "interpretation", // fast decay: 0.97^200 ≈ 0.0026 — very stale
+      fact: "Stale interpretation fact",
+      provenance: {
+        source_agent: "test-agent",
+        timestamp: oldDate.toISOString(),
+        basis: "inferred",
+        confidence: 0.9,
+      },
+    }));
+
+    const read = await readOne(entry.id, "test-reader");
+    assert.equal(read.stale, true, "should be stale after 200 days with fast decay");
+  });
+
+  test("challenge warning prepended when challenges exist", async () => {
+    await clearPool();
+    // Manually inject an entry with challenges
+    const pool = { version: "0.2", entries: [] };
+    const challengeEntry = {
+      id: "challenge-test-001",
+      type: "fact",
+      category: "test",
+      fact: "Contested fact",
+      tags: [],
+      provenance: {
+        source_agent: "agent-x",
+        timestamp: new Date().toISOString(),
+        basis: "observed",
+        confidence: 0.8,
+        review_by: "2027-01-01",
+      },
+      confirmed_by: null,
+      decay_rate: "slow",
+      challenges: [{ source: "agent-y", reason: "I observed differently" }],
+    };
+    pool.entries.push(challengeEntry);
+    await writeFile(POOL_FILE, JSON.stringify(pool, null, 2));
+
+    const { readOne } = await import(`../shared-pool-read.mjs?t=${Date.now()}`);
+    const entry = await readOne("challenge-test-001");
+    assert.ok(entry._warning, "should have challenge warning");
+    assert.ok(entry._warning.includes("[CHALLENGE]"));
+  });
+});
+
+// ─── Blind gate tests ─────────────────────────────────────────────────────────
+
+describe("blind-gate", () => {
+  before(async () => {
+    await clearPool();
+    // Write a test entry
+    const { writeEntry } = await import(`../shared-pool-write.mjs?t=${Date.now()}`);
+    await writeEntry(makeEntry({ fact: "Gate test fact" }));
+    // Clear any old gates
+    if (existsSync(GATES_DIR)) {
+      await rm(GATES_DIR, { recursive: true });
+    }
+  });
+
+  after(async () => {
+    await restorePool();
+  });
+
+  test("readWithGate without token — throws with protocol explanation", async () => {
+    const { readWithGate } = await import(`../blind-gate.mjs?t=${Date.now()}`);
+    await assert.rejects(
+      () => readWithGate(null, {}),
+      /No gate token provided/
+    );
+  });
+
+  test("readWithGate with invalid token — throws", async () => {
+    const { readWithGate } = await import(`../blind-gate.mjs?t=${Date.now()}`);
+    // May say "gate not found" or "gates directory not found" depending on state
+    await assert.rejects(
+      () => readWithGate("invalid-token-xyz"),
+      /Gate token not found|No gates directory found/
+    );
+  });
+
+  test("openGate returns a token", async () => {
+    const { openGate } = await import(`../blind-gate.mjs?t=${Date.now()}`);
+    const token = await openGate("test-topic", "test-agent", "My independent position");
+    assert.ok(typeof token === "string" && token.length > 0);
+  });
+
+  test("valid gate — readWithGate succeeds and returns entries", async () => {
+    const { openGate, readWithGate } = await import(`../blind-gate.mjs?t=${Date.now()}`);
+    const token = await openGate("deployment", "agent-a", "I think deployment is ready");
+    const entries = await readWithGate(token, { includeStale: true });
+    assert.ok(Array.isArray(entries));
+  });
+
+  test("valid gate — marked used after read", async () => {
+    const { openGate, readWithGate } = await import(`../blind-gate.mjs?t=${Date.now()}`);
+    const token = await openGate("used-gate-topic", "agent-b", "My position here");
+    await readWithGate(token, { includeStale: true });
+
+    // Second read with same token should fail
+    await assert.rejects(
+      () => readWithGate(token, {}),
+      /already used/
+    );
+  });
+
+  test("expired gate — throws with expiry message", async () => {
+    const { openGate } = await import(`../blind-gate.mjs?t=${Date.now()}`);
+    const { readWithGate } = await import(`../blind-gate.mjs?t=${Date.now()}`);
+
+    const token = await openGate("expiry-test", "agent-c", "My position");
+
+    // Manually backdate the gate file to simulate expiry
+    const { readdir } = await import("node:fs/promises");
+    const files = await readdir(GATES_DIR);
+    for (const file of files) {
+      const path = resolve(GATES_DIR, file);
+      const data = JSON.parse(readFileSync(path, "utf-8"));
+      if (data.token === token) {
+        data.openedAt = new Date(Date.now() - 11 * 60 * 1000).toISOString(); // 11 min ago
+        writeFileSync(path, JSON.stringify(data, null, 2));
+      }
+    }
+
+    await assert.rejects(
+      () => readWithGate(token, {}),
+      /expired/
+    );
+  });
+
+  test("hasActiveGate returns true when gate is open", async () => {
+    const { openGate, hasActiveGate } = await import(`../blind-gate.mjs?t=${Date.now()}`);
+    await openGate("active-test", "agent-d", "My position");
+    const active = await hasActiveGate("agent-d");
+    assert.equal(active, true);
+  });
+
+  test("hasActiveGate returns false when no gate", async () => {
+    const { hasActiveGate } = await import(`../blind-gate.mjs?t=${Date.now()}`);
+    const active = await hasActiveGate("agent-nonexistent-xyz");
+    assert.equal(active, false);
+  });
+});
+
+// ─── Sync / receiveFromPeer tests ─────────────────────────────────────────────
+
+describe("shared-pool-sync", () => {
+  before(async () => {
+    await clearPool();
+  });
+
+  after(async () => {
+    await restorePool();
+  });
+
+  test("receiveFromPeer forces basis to 'peer-relayed'", async () => {
+    const { receiveFromPeer } = await import(`../shared-pool-sync.mjs?t=${Date.now()}`);
+    const ts = new Date().toISOString();
+    const entry = {
+      id: `peer-relay-${randomUUID().slice(0, 8)}`,
+      type: "fact",
+      category: "test",
+      fact: `Peer relay test fact ${randomUUID()}`,
+      tags: ["peer-test"],
+      provenance: {
+        source_agent: "remote-agent",
+        timestamp: ts,
+        basis: "observed", // will be overridden to "peer-relayed"
+        confidence: 0.85,
+        review_by: new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10),
+      },
+      decay_rate: "slow",
+      challenges: [],
+    };
+
+    const result = await receiveFromPeer(entry);
+    assert.equal(result.provenance.basis, "peer-relayed", "basis must be forced to peer-relayed");
+  });
+
+  test("receiveFromPeer duplicate ID — throws with DUPLICATE code", async () => {
+    const { receiveFromPeer } = await import(`../shared-pool-sync.mjs?t=${Date.now()}`);
+    const ts = new Date().toISOString();
+    const fixedId = `dup-peer-${randomUUID().slice(0, 8)}`;
+    const entry = {
+      id: fixedId,
+      type: "fact",
+      category: "test",
+      fact: `Duplicate peer fact ${randomUUID()}`,
+      tags: [],
+      provenance: {
+        source_agent: "remote-agent",
+        timestamp: ts,
+        basis: "observed",
+        confidence: 0.85,
+        review_by: new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10),
+      },
+      decay_rate: "slow",
+      challenges: [],
+    };
+
+    await receiveFromPeer(entry);
+
+    const err = await receiveFromPeer({ ...entry, fact: "Modified fact" }).catch(e => e);
+    assert.ok(err instanceof Error);
+    assert.equal(err.code, "DUPLICATE");
+  });
+
+  test("receiveFromPeer invalid entry — throws with INVALID code", async () => {
+    const { receiveFromPeer } = await import(`../shared-pool-sync.mjs?t=${Date.now()}`);
+    const err = await receiveFromPeer({ fact: "missing required fields" }).catch(e => e);
+    assert.ok(err instanceof Error);
+    assert.equal(err.code, "INVALID");
+  });
+
+  test("receiveFromPeer missing fact — throws INVALID", async () => {
+    const { receiveFromPeer } = await import(`../shared-pool-sync.mjs?t=${Date.now()}`);
+    const entry = makeEntry();
+    delete entry.fact;
+    const err = await receiveFromPeer(entry).catch(e => e);
+    assert.equal(err.code, "INVALID");
+  });
+});
+
+console.log("\n✅ shared-pool.test.mjs loaded — running tests...\n");


### PR DESCRIPTION
## Summary

Implements the shared memory pool architecture designed in `research/CONSENSUS_BIAS_ARCHITECTURE.md` — the result of a three-agent consensus process (Ray, Liz, Woodhouse).

## What's in this PR

### New modules
- **`shared-pool-write.mjs`** — Write entries with full validation, deterministic ID (sha256), type-derived `decay_rate`, computed `review_by` dates, and seed merging on first init
- **`shared-pool-read.mjs`** — Read-path anonymization (source_agent stripped, replaced with role), temporal confidence decay (slow/medium/fast/bounded), stale flag at <0.5 confidence, challenge warnings, full audit trail in `audit.jsonl`
- **`blind-gate.mjs`** — Pre-retrieval commitment gate: agent commits a position hash *before* reading the pool, preventing anchoring bias. Gates are 10-min single-use tokens.
- **`shared-pool-sync.mjs`** — Peer sync via POST /mesh/shared-pool; forces `basis=peer-relayed` on all received entries; 1 req/sec/peer rate limit; cursor tracking in sync-state.json

### Updates
- **`memory-receiver.mjs`** — Added `POST /mesh/shared-pool` route (201 success, 409 duplicate, 400 invalid)
- **`package.json`** — Added `shared-pool` and `test:pool` scripts
- **`DEPLOY.md`** — Shared Pool section with usage examples
- **`README.md`** — Feature list updated

## Tests
- `tests/shared-pool.test.mjs` — 29 tests, **all pass**
- `tests/bug-fixes.test.mjs` — 14 suites, **all pass** (full regression)

## Architecture highlights
- Type system: observation | fact | inference | interpretation | role-assignment | prediction
- Default-to-interpretation when type is missing (with warning)
- Read-path anonymization is mandatory — not optional
- Blind gate is architectural, not policy — throws if skipped
- Temporal decay is applied at read time, never mutating the pool
- Peer entries always receive basis=peer-relayed (bias provenance tracking)