### PR TITLE
fix: add tunnel publisher peer send hook

### DIFF
--- a/tunnel-publisher.mjs
+++ b/tunnel-publisher.mjs
@@ -288,6 +288,22 @@ export class TunnelPublisher {
   }
 
   /**
+   * Low-level send hook used by publishFact(). Kept as an instance method so
+   * tests can stub peer responses without opening sockets.
+   * @param {Object} peer - Peer descriptor with url and optional token
+   * @param {Object} fact - The fact to publish
+   * @returns {Promise<Object>} HTTP-like publish result
+   */
+  async publishToPeer(peer, fact) {
+    return postFactToPeer(
+      fact,
+      peer,
+      peer.token || this.token,
+      this.correlationId
+    );
+  }
+
+  /**
    * Publishes a single fact to all configured peers.
    * Validates the fact before sending.
    * Retries failed publishes with exponential backoff.


### PR DESCRIPTION
## Summary
- Add `TunnelPublisher.publishToPeer(peer, fact)` as the instance hook used by `publishFact()`
- Delegate to the existing `postFactToPeer(...)` HTTP path with peer-token fallback and publisher correlation id
- Keeps tests able to stub peer publishing without opening sockets

Fixes #17

## Verification
- `node --check tunnel-publisher.mjs`
- `git diff --check`
- `node --test tests/tunnel-publisher.test.mjs`

Opened after maintainer invitation in #17.