### PR TITLE
identity-passport: validate agentName in getByName (return null on in…

### DIFF
--- a/src/identity-passport.mjs
+++ b/src/identity-passport.mjs
@@ -409,6 +409,9 @@ export class PassportRegistry {
    * Get passport by agent name
    */
   async getByName(agentName) {
+    if (typeof agentName !== 'string' || agentName.length === 0) {
+      return null;
+    }
     const path = join(this.registryPath, `${agentName}.json`);
     if (!existsSync(path)) {
       return null;

--- a/tests/identity-passport.test.mjs
+++ b/tests/identity-passport.test.mjs
@@ -306,6 +306,24 @@ describe('PassportRegistry', () => {
     assert.strictEqual(retrieved, null);
   });
 
+  it('should return null for invalid input types', async () => {
+    // null-path guard: getByName must return null (not throw, not return malformed
+    // data) for invalid agentName inputs. Pinned by Kosfootel/agent-shared#9.
+    const registry = new PassportRegistry(registryDir);
+    
+    const retrievedNull = await registry.getByName(null);
+    assert.strictEqual(retrievedNull, null, 'null should return null');
+    
+    const retrievedUndefined = await registry.getByName(undefined);
+    assert.strictEqual(retrievedUndefined, null, 'undefined should return null');
+    
+    const retrievedEmpty = await registry.getByName('');
+    assert.strictEqual(retrievedEmpty, null, 'empty string should return null');
+    
+    const retrievedNumber = await registry.getByName(123);
+    assert.strictEqual(retrievedNumber, null, 'number should return null');
+  });
+
   it('should verify peer identity', async () => {
     const registry = new PassportRegistry(registryDir);
     


### PR DESCRIPTION
…valid input)

Fleet-maintenance (back of house) automated fix. getByName built a file path from agentName without validation; for null/undefined/non-string/empty input it now returns null, consistent with the method's existing not-found -> null contract.

Gates (gx10-dev-pod gates.py, dry-run): robust SEARCH/REPLACE apply=PASS; differential tests 17/17 baseline vs 17/17 patched (no regression); review=PASS; governance=APPROVE; risk tier 1. Suggest-only pipeline; opened for human review, NOT auto-merged.

## Summary

<!-- What does this PR do? One paragraph. -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Protocol/API change (RFC required)
- [ ] Architecture change (ADR required)
- [ ] Incident fix (post-mortem required)
- [ ] Documentation / tooling

---

## QA Gate Checklist

All boxes must be checked before merge is allowed.

### Tests
- [ ] `npm test` passes locally — all tests green
- [ ] No tests were deleted or disabled to make the suite pass

### QA Report (MVP work only — skip for POC/docs)
- [ ] `QA_REPORT.md` (or `QA_REPORT_*.md`) exists in this branch and is committed
- [ ] QA report covers the changed functionality

### Privacy Scan
- [ ] No `192.168.x.x` private IPs in changed files
- [ ] No tokens or secrets (`sk-`, 40+ char hex strings, `Bearer` credentials)
- [ ] No `/home/erik-ross/` local paths in source files
- [ ] No `.local` domain names or internal hostnames
- [ ] Config secrets use `*.config.local.json` (gitignored), not hardcoded values

---

## Protocol / Architecture Compliance

### If this PR changes a protocol endpoint, message format, or API contract:
- [ ] RFC filed and accepted (RFC-NNNN: _______)
- [ ] N/A — no protocol or API changes

### If this PR makes an architectural decision (new abstraction, new dependency, data model change):
- [ ] ADR filed and linked in this PR (ADR-NNNN: _______)
- [ ] N/A — no architectural decisions

### If this PR fixes an incident or production failure:
- [ ] Post-mortem filed at `projects/incubate/postmortems/YYYY-MM-DD-incident-name.md`
- [ ] Post-mortem entry added to `COMPLIANCE_LOG.md`
- [ ] N/A — not an incident fix

---

## Compliance Log

If any RFC, ADR, or post-mortem was filed for this PR:
- [ ] Entry added to `projects/incubate/COMPLIANCE_LOG.md` in Kosfootel/better-machine

---

## Test Evidence

<!-- Paste test output or QA report summary here -->

```
npm test output:
```

---

## Reviewer Notes

<!-- Anything the reviewer should know, watch out for, or specifically validate -->
